### PR TITLE
This enables builds to not fail when using Xcode 9  beta 1

### DIFF
--- a/lib/ios/native-navigation/Dictionary+FunctionalExtensions.swift
+++ b/lib/ios/native-navigation/Dictionary+FunctionalExtensions.swift
@@ -40,7 +40,8 @@ extension Dictionary {
     return dict
   }
 
-
+#if swift(>=3.2)
+#else
   public func mapValues<OutValue>(transform: (Value) throws -> OutValue) rethrows -> [Key: OutValue] {
     var dict = [Key: OutValue]()
     for (key, value) in self {
@@ -48,4 +49,5 @@ extension Dictionary {
     }
     return dict
   }
+#endif
 }


### PR DESCRIPTION
Swift 4 introduces mapValues as a method on Dictionary and Xcode 9 gets annoyed if we override it.
After this change mapValues is only added by us to swift versions below 4